### PR TITLE
fix: update GitHub Actions workflow for documentation repository

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -33,9 +33,9 @@ jobs:
       - name: Checkout docs with SSH
         uses: actions/checkout@v3
         with:
-          repository: bucketco/docs
+          repository: reflag/docs
           ssh-key: ${{ secrets.DOCS_DEPLOY_KEY }}
-          path: bucket-docs
+          path: reflag-docs
       - name: Copy generated docs to docs repo
         run: |
           rm -rf reflag-docs/sdk


### PR DESCRIPTION
- Changed the repository reference from `bucketco/docs` to `reflag/docs`.
- Updated the path for the checked-out documentation from `bucket-docs` to `reflag-docs`.