### PR TITLE
fix: update documentation repository reference in GitHub Actions workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Checkout docs with SSH
         uses: actions/checkout@v3
         with:
-          repository: reflag/docs
+          repository: reflagcom/docs
           ssh-key: ${{ secrets.DOCS_DEPLOY_KEY }}
           path: reflag-docs
       - name: Copy generated docs to docs repo

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -42,8 +42,11 @@
   "cSpell.words": [
     "booleanish",
     "bucketco",
+    "npmjs",
+    "nvmrc",
     "openfeature",
     "PKCE",
-    "Reflag"
+    "Reflag",
+    "reflagcom"
   ]
 }


### PR DESCRIPTION
- Changed the repository reference from `reflag/docs` to `reflagcom/docs`.
- Updated the spelling of `reflag` to `reflagcom` in VSCode settings for spell checking.