### PR TITLE
chore: Update CLI MCP handling

### DIFF
--- a/packages/cli/commands/mcp.ts
+++ b/packages/cli/commands/mcp.ts
@@ -16,10 +16,7 @@ import {
 import { configStore } from "../stores/config.js";
 import { handleError } from "../utils/errors.js";
 import { fileExists } from "../utils/file.js";
-import {
-  configScopeOption,
-  editorOption,
-} from "../utils/options.js";
+import { configScopeOption, editorOption } from "../utils/options.js";
 
 export const mcpAction = async (options: {
   editor?: SupportedEditor;

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reflag/cli",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "packageManager": "yarn@4.1.1",
   "description": "CLI for Reflag service",
   "main": "./dist/index.js",


### PR DESCRIPTION
We do not require `appId` anymore, make sure we don't add it any longer