### PR TITLE
Prevent prototype pollution in JSON unflattening

### DIFF
--- a/.changeset/safe-ravens-unflatten.md
+++ b/.changeset/safe-ravens-unflatten.md
@@ -1,0 +1,5 @@
+---
+"@reflag/flag-evaluation": patch
+---
+
+Prevent prototype pollution when unflattening JSON with unsafe property paths.

--- a/packages/flag-evaluation/src/index.ts
+++ b/packages/flag-evaluation/src/index.ts
@@ -254,9 +254,16 @@ export function flattenJSON(data: object): Record<string, string> {
  */
 export function unflattenJSON(data: Record<string, any>): Record<string, any> {
   const result: Record<string, any> = {};
+  // Traversing these properties on a plain object can reach Object.prototype.
+  const unsafePathSegments = new Set(["__proto__", "constructor", "prototype"]);
 
-  for (const i in data) {
+  for (const i of Object.keys(data)) {
     const keys = i.split(".");
+
+    if (keys.some((key) => unsafePathSegments.has(key))) {
+      continue;
+    }
+
     keys.reduce((acc, key, index) => {
       if (index === keys.length - 1) {
         if (typeof acc === "object") {

--- a/packages/flag-evaluation/test/index.test.ts
+++ b/packages/flag-evaluation/test/index.test.ts
@@ -1202,6 +1202,33 @@ describe("unflattenJSON", () => {
     expect(output).toEqual({});
   });
 
+  it("should prevent prototype pollution", () => {
+    const unexpectedProperties = [
+      "unexpectedConstructorPathProperty",
+      "unexpectedProtoPathProperty",
+    ];
+
+    for (const property of unexpectedProperties) {
+      delete Object.prototype[property];
+    }
+
+    try {
+      const output = unflattenJSON({
+        "constructor.prototype.unexpectedConstructorPathProperty": "value",
+        "__proto__.unexpectedProtoPathProperty": "value",
+      });
+
+      expect(output).toEqual({});
+      for (const property of unexpectedProperties) {
+        expect(Object.hasOwn(Object.prototype, property)).toBe(false);
+      }
+    } finally {
+      for (const property of unexpectedProperties) {
+        delete Object.prototype[property];
+      }
+    }
+  });
+
   it("should convert a flat object with one level deep keys to a nested object", () => {
     const input = {
       "a.b.c": "value",

--- a/packages/flag-evaluation/test/index.test.ts
+++ b/packages/flag-evaluation/test/index.test.ts
@@ -1220,7 +1220,9 @@ describe("unflattenJSON", () => {
 
       expect(output).toEqual({});
       for (const property of unexpectedProperties) {
-        expect(Object.hasOwn(Object.prototype, property)).toBe(false);
+        expect(
+          Object.prototype.hasOwnProperty.call(Object.prototype, property),
+        ).toBe(false);
       }
     } finally {
       for (const property of unexpectedProperties) {


### PR DESCRIPTION
## Summary

- prevent `unflattenJSON` from traversing unsafe prototype-related path segments
- process only own properties from the flattened input
- add regression coverage for `constructor.prototype` and `__proto__` paths
- add a patch changeset for `@reflag/flag-evaluation`

The Changesets release flow will also patch dependent packages, including `@reflag/node-sdk`, so they resolve the fixed evaluation package.

## Validation

- `@reflag/flag-evaluation`: 145 tests passed
- `@reflag/node-sdk`: 218 tests passed
- TypeScript builds passed for both packages
- lint and formatting checks passed
