### PR TITLE
Fix Vue event cleanup before component mount

### DIFF
--- a/.changeset/slow-ravens-listen.md
+++ b/.changeset/slow-ravens-listen.md
@@ -1,0 +1,5 @@
+---
+"@reflag/vue-sdk": patch
+---
+
+Avoid calling an uninitialized event cleanup function when a suspended component unmounts before mounting.

--- a/packages/vue-sdk/src/hooks.ts
+++ b/packages/vue-sdk/src/hooks.ts
@@ -390,12 +390,12 @@ export function useOnEvent<THookType extends keyof HookArgs>(
   client?: ReflagClient,
 ) {
   const resolvedClient = client ?? useClient();
-  let off: () => void;
+  let off: (() => void) | undefined;
   onMounted(() => {
     off = resolvedClient.on(event, handler);
   });
   onUnmounted(() => {
-    off();
+    off?.();
   });
 }
 

--- a/packages/vue-sdk/test/usage.test.ts
+++ b/packages/vue-sdk/test/usage.test.ts
@@ -1,6 +1,6 @@
 import { mount } from "@vue/test-utils";
 import { beforeAll, beforeEach, describe, expect, test, vi } from "vitest";
-import { defineComponent, h, nextTick } from "vue";
+import { defineComponent, h, nextTick, Suspense } from "vue";
 
 import { ReflagClient } from "@reflag/browser-sdk";
 
@@ -9,6 +9,7 @@ import {
   ReflagProvider,
   useClient,
   useFlag,
+  useOnEvent,
   useOptInFlags,
   useSetOptIn,
 } from "../src";
@@ -75,6 +76,30 @@ describe("ReflagProvider", () => {
 
     await nextTick();
     expect(wrapper.findComponent(Child).vm.client).toBeDefined();
+  });
+
+  test("does not throw when unmounted before an event listener is registered", () => {
+    const AsyncChild = defineComponent({
+      setup() {
+        useOnEvent("flagsUpdated", vi.fn());
+        return new Promise(() => {
+          // Remain suspended until the component is unmounted.
+        });
+      },
+    });
+
+    const wrapper = mount(ReflagProvider, {
+      ...getProvider(),
+      slots: {
+        default: () =>
+          h(Suspense, null, {
+            default: () => h(AsyncChild),
+            fallback: () => h("div"),
+          }),
+      },
+    });
+
+    expect(() => wrapper.unmount()).not.toThrow();
   });
 
   test("enables live flag updates by default", async () => {


### PR DESCRIPTION
## Summary
- guard `useOnEvent` cleanup when a component unmounts before its mounted hook runs
- add a regression test covering an async component suspended and unmounted before listener registration
- add a patch changeset for `@reflag/vue-sdk`

## Root cause
Vue Suspense can unmount a component after setup but before `onMounted`. In that case `onUnmounted` ran with an uninitialized listener cleanup callback, producing the minified `TypeError: o is not a function`.

## Validation
- Vue SDK typecheck
- Vue SDK tests (13 passed)
- Vue SDK build
- oxlint
- oxfmt