### PR TITLE
Avoid leaking toolbar UI from React SDK tests

### DIFF
--- a/packages/react-sdk/test/usage.test.tsx
+++ b/packages/react-sdk/test/usage.test.tsx
@@ -201,7 +201,6 @@ describe("<ReflagProvider />", () => {
       staleWhileRevalidate: true,
       fallbackFlags: ["flag2"],
       feedback: { enableAutoFeedback: true },
-      toolbar: { show: true },
     });
 
     render(provider);
@@ -871,7 +870,6 @@ describe("<ReflagBootstrappedProvider />", () => {
         staleWhileRevalidate: true,
         fallbackFlags: ["flag2"],
         feedback: { enableAutoFeedback: true },
-        toolbar: { show: true },
         children: <span>Test Content</span>,
       }),
     );


### PR DESCRIPTION
## Summary
- keep toolbar rendering disabled in React provider tests that do not exercise toolbar behavior
- prevent the Preact toolbar from scheduling work after Vitest tears down jsdom

## Context
The Package CI run for #703 intermittently failed after all React SDK assertions passed because a toolbar render ran after teardown and accessed the removed `sessionStorage` global. Toolbar behavior is covered by the browser SDK tests; these provider tests only verify initialization and bootstrapped rendering.

## Validation
- React SDK tests (63 passed)
- oxlint
- oxfmt