### PR TITLE
Support array membership and singleton equality

### DIFF
--- a/.changeset/array-contains-membership.md
+++ b/.changeset/array-contains-membership.md
@@ -5,4 +5,6 @@
 
 Fix `CONTAINS` and `NOT_CONTAINS` for array-valued context. `CONTAINS` now checks for an exact, case-sensitive array element; `NOT_CONTAINS` checks its absence. Both use the first comparison value, while `ANY_OF` and `NOT_ANY_OF` continue to support multiple comparison values. Empty arrays do not contain any value.
 
-Scalar strings retain case-insensitive substring matching. Supported array membership checks no longer produce `UNSUPPORTED_ARRAY_OPERATOR` warnings in Node SDK flag targeting or config evaluation.
+Support `IS` for arrays containing exactly one element equal to the comparison value; `IS_NOT` matches all other present arrays, including empty arrays and arrays with duplicate matching elements. Missing fields still fail closed. Scalar equality is unchanged.
+
+Scalar strings retain case-insensitive substring matching. Supported array equality and membership checks no longer produce `UNSUPPORTED_ARRAY_OPERATOR` warnings in Node SDK flag targeting or config evaluation.

--- a/.changeset/array-contains-membership.md
+++ b/.changeset/array-contains-membership.md
@@ -1,0 +1,8 @@
+---
+"@reflag/flag-evaluation": patch
+"@reflag/node-sdk": patch
+---
+
+Fix `CONTAINS` and `NOT_CONTAINS` for array-valued context. `CONTAINS` now checks for an exact, case-sensitive array element; `NOT_CONTAINS` checks its absence. Both use the first comparison value, while `ANY_OF` and `NOT_ANY_OF` continue to support multiple comparison values. Empty arrays do not contain any value.
+
+Scalar strings retain case-insensitive substring matching. Supported array membership checks no longer produce `UNSUPPORTED_ARRAY_OPERATOR` warnings in Node SDK flag targeting or config evaluation.

--- a/packages/flag-evaluation/src/index.ts
+++ b/packages/flag-evaluation/src/index.ts
@@ -63,8 +63,8 @@ export type FilterTree<T extends FilterClass> =
  * - "IS_NOT": Specifies a negation of exact match.
  * - "ANY_OF": Checks if a value is present in a set of specified values.
  * - "NOT_ANY_OF": Checks if a value is not present in a set of specified values.
- * - "CONTAINS": Verifies if a value contains a specific substring or element.
- * - "NOT_CONTAINS": Verifies if a value does not contain a specific substring or element.
+ * - "CONTAINS": Case-insensitive substring match for strings; exact, case-sensitive element membership for arrays.
+ * - "NOT_CONTAINS": Negates substring matching for strings or element membership for arrays.
  * - "GT": Greater than comparison.
  * - "LT": Less than comparison.
  * - "AFTER": Compares if a value is after a specified point (e.g., time, rank).
@@ -374,6 +374,8 @@ export function hashInt(hashInput: string): number {
 }
 
 const ARRAY_OPERATORS = new Set<ContextFilterOperator>([
+  "CONTAINS",
+  "NOT_CONTAINS",
   "ANY_OF",
   "NOT_ANY_OF",
   "SET",
@@ -393,6 +395,14 @@ export function evaluate(
 
   if (Array.isArray(normalizedFieldValue)) {
     switch (operator) {
+      case "CONTAINS":
+        return (
+          typeof value === "string" && normalizedFieldValue.includes(value)
+        );
+      case "NOT_CONTAINS":
+        return (
+          typeof value === "string" && !normalizedFieldValue.includes(value)
+        );
       case "ANY_OF": {
         const candidates = valueSet ?? new Set(values);
         return normalizedFieldValue.some((entry) => candidates.has(entry));
@@ -406,7 +416,7 @@ export function evaluate(
       case "NOT_SET":
         return normalizedFieldValue.length === 0;
       default:
-        // Exact, textual, numeric, date, and boolean operators are scalar-only.
+        // Scalar equality, numeric, date, and boolean operators are scalar-only.
         // Do not accidentally stringify arrays for comparison.
         return false;
     }

--- a/packages/flag-evaluation/src/index.ts
+++ b/packages/flag-evaluation/src/index.ts
@@ -59,8 +59,8 @@ export type FilterTree<T extends FilterClass> =
  * set membership, and boolean evaluations.
  *
  * Possible values:
- * - "IS": Specifies exact match.
- * - "IS_NOT": Specifies a negation of exact match.
+ * - "IS": Exact scalar match, or an array containing exactly one matching element.
+ * - "IS_NOT": Negates scalar equality or singleton-array equality.
  * - "ANY_OF": Checks if a value is present in a set of specified values.
  * - "NOT_ANY_OF": Checks if a value is not present in a set of specified values.
  * - "CONTAINS": Case-insensitive substring match for strings; exact, case-sensitive element membership for arrays.
@@ -374,6 +374,8 @@ export function hashInt(hashInput: string): number {
 }
 
 const ARRAY_OPERATORS = new Set<ContextFilterOperator>([
+  "IS",
+  "IS_NOT",
   "CONTAINS",
   "NOT_CONTAINS",
   "ANY_OF",
@@ -395,6 +397,20 @@ export function evaluate(
 
   if (Array.isArray(normalizedFieldValue)) {
     switch (operator) {
+      case "IS":
+        return (
+          typeof value === "string" &&
+          normalizedFieldValue.length === 1 &&
+          normalizedFieldValue[0] === value
+        );
+      case "IS_NOT":
+        return (
+          typeof value === "string" &&
+          !(
+            normalizedFieldValue.length === 1 &&
+            normalizedFieldValue[0] === value
+          )
+        );
       case "CONTAINS":
         return (
           typeof value === "string" && normalizedFieldValue.includes(value)
@@ -416,7 +432,7 @@ export function evaluate(
       case "NOT_SET":
         return normalizedFieldValue.length === 0;
       default:
-        // Scalar equality, numeric, date, and boolean operators are scalar-only.
+        // Numeric, date, and boolean operators are scalar-only.
         // Do not accidentally stringify arrays for comparison.
         return false;
     }

--- a/packages/flag-evaluation/test/index.test.ts
+++ b/packages/flag-evaluation/test/index.test.ts
@@ -8,6 +8,7 @@ import {
   flattenJSON,
   hashInt,
   newEvaluator,
+  Rule,
   unflattenJSON,
 } from "../src";
 
@@ -549,6 +550,69 @@ describe("evaluate flag targeting integration ", () => {
       });
     });
 
+    describe.each(["CONTAINS", "NOT_CONTAINS"] as const)(
+      "%s normalization",
+      (operator) => {
+        it.each(["admin", "2", "true", "", '{"level":3}', "[false]"])(
+          "matches normalized element %j without diagnostics",
+          (value) => {
+            const rules: Rule<string>[] = [
+              {
+                value: "matched",
+                filter: {
+                  type: "context",
+                  field: "user.roles",
+                  operator,
+                  values: [value],
+                },
+              },
+            ];
+            const context = {
+              user: { roles: ["admin", 2, true, null, { level: 3 }, [false]] },
+            };
+            const expected = operator === "CONTAINS";
+            for (const result of [
+              evaluateFlagRules({ flagKey: "array", rules, context }),
+              newEvaluator(rules)(context, "array"),
+            ]) {
+              expect(result.value).toBe(expected ? "matched" : undefined);
+              expect(result.ruleEvaluationResults).toEqual([expected]);
+              expect(result.errors).toBeUndefined();
+              expect(result.missingContextFields).toEqual([]);
+            }
+          },
+        );
+      },
+    );
+
+    it.each(["CONTAINS", "NOT_CONTAINS"] as const)(
+      "allows negation of array %s without treating it as an error",
+      (operator) => {
+        const result = evaluateFlagRules({
+          flagKey: "negated-membership",
+          rules: [
+            {
+              value: true,
+              filter: {
+                type: "negation",
+                filter: {
+                  type: "context",
+                  field: "user.roles",
+                  operator,
+                  values: ["admin"],
+                },
+              },
+            },
+          ],
+          context: { user: { roles: ["admin"] } },
+        });
+        expect(result.ruleEvaluationResults).toEqual([
+          operator === "NOT_CONTAINS",
+        ]);
+        expect(result.errors).toBeUndefined();
+      },
+    );
+
     it("keeps JSON-looking strings scalar", () => {
       const evaluator = newEvaluator([
         {
@@ -606,7 +670,7 @@ describe("evaluate flag targeting integration ", () => {
             filter: {
               type: "context",
               field: "user.roles",
-              operator: "CONTAINS",
+              operator: "IS",
               values: ["admin"],
             },
           },
@@ -620,9 +684,9 @@ describe("evaluate flag targeting integration ", () => {
         {
           code: "UNSUPPORTED_ARRAY_OPERATOR",
           field: "user.roles",
-          operator: "CONTAINS",
+          operator: "IS",
           message:
-            'Operator CONTAINS does not support array-valued context field "user.roles".',
+            'Operator IS does not support array-valued context field "user.roles".',
         },
       ]);
     });
@@ -638,7 +702,7 @@ describe("evaluate flag targeting integration ", () => {
               filter: {
                 type: "context",
                 field: "user.roles",
-                operator: "CONTAINS",
+                operator: "IS",
                 values: ["admin"],
               },
             },
@@ -1054,10 +1118,27 @@ describe("operator evaluation", () => {
     "returns false for %s without comparison values",
     (operator) => {
       expect(evaluate("value", operator, [])).toBe(false);
+      expect(evaluate(["value"], operator, [])).toBe(false);
+      expect(evaluate([], operator, [])).toBe(false);
     },
   );
 
   it.each([
+    [["a", "b"], "CONTAINS", ["a"], true],
+    [["a", "b"], "CONTAINS", ["c"], false],
+    [["a", "b"], "NOT_CONTAINS", ["c"], true],
+    [["a", "b"], "NOT_CONTAINS", ["a"], false],
+    [["admin"], "CONTAINS", ["adm"], false],
+    [["admin"], "NOT_CONTAINS", ["adm"], true],
+    [["Admin"], "CONTAINS", ["admin"], false],
+    [["Admin"], "NOT_CONTAINS", ["admin"], true],
+    [[], "CONTAINS", ["a"], false],
+    [[], "NOT_CONTAINS", ["a"], true],
+    [[""], "CONTAINS", [""], true],
+    [["a"], "CONTAINS", [""], false],
+    [["a", "a"], "CONTAINS", ["a"], true],
+    [["a"], "CONTAINS", ["b", "a"], false],
+    [["a"], "NOT_CONTAINS", ["b", "a"], true],
     [["a", "b"], "ANY_OF", ["a"], true],
     [["a", "b"], "ANY_OF", ["c"], false],
     [["a", "b"], "ANY_OF", ["b", "c"], true],
@@ -1083,8 +1164,6 @@ describe("operator evaluation", () => {
   it.each([
     "IS",
     "IS_NOT",
-    "CONTAINS",
-    "NOT_CONTAINS",
     "GT",
     "LT",
     "AFTER",

--- a/packages/flag-evaluation/test/index.test.ts
+++ b/packages/flag-evaluation/test/index.test.ts
@@ -613,6 +613,70 @@ describe("evaluate flag targeting integration ", () => {
       },
     );
 
+    describe.each(["IS", "IS_NOT"] as const)(
+      "%s singleton arrays",
+      (operator) => {
+        it.each([
+          { entries: [2], candidate: "2", equal: true },
+          { entries: [true], candidate: "true", equal: true },
+          { entries: [null], candidate: "", equal: true },
+          { entries: [{ level: 3 }], candidate: '{"level":3}', equal: true },
+          { entries: [[false]], candidate: "[false]", equal: true },
+          { entries: [2, 2], candidate: "2", equal: false },
+          { entries: [], candidate: "2", equal: false },
+        ])(
+          "evaluates $entries against $candidate without errors",
+          ({ entries, candidate, equal }) => {
+            const rules: Rule<boolean>[] = [
+              {
+                value: true,
+                filter: {
+                  type: "context",
+                  field: "user.roles",
+                  operator,
+                  values: [candidate],
+                },
+              },
+            ];
+            const context = { user: { roles: entries } };
+            for (const result of [
+              evaluateFlagRules({ flagKey: "singleton", rules, context }),
+              newEvaluator(rules)(context, "singleton"),
+            ]) {
+              expect(result.ruleEvaluationResults).toEqual([
+                operator === "IS" ? equal : !equal,
+              ]);
+              expect(result.errors).toBeUndefined();
+            }
+          },
+        );
+
+        it("fails closed for missing fields, even under negation", () => {
+          const result = evaluateFlagRules({
+            flagKey: "missing",
+            rules: [
+              {
+                value: true,
+                filter: {
+                  type: "negation",
+                  filter: {
+                    type: "context",
+                    field: "user.roles",
+                    operator,
+                    values: ["admin"],
+                  },
+                },
+              },
+            ],
+            context: { user: {} },
+          });
+          expect(result.ruleEvaluationResults).toEqual([false]);
+          expect(result.missingContextFields).toEqual(["user.roles"]);
+          expect(result.errors?.[0].code).toBe("MISSING_CONTEXT_FIELD");
+        });
+      },
+    );
+
     it("keeps JSON-looking strings scalar", () => {
       const evaluator = newEvaluator([
         {
@@ -670,7 +734,7 @@ describe("evaluate flag targeting integration ", () => {
             filter: {
               type: "context",
               field: "user.roles",
-              operator: "IS",
+              operator: "GT",
               values: ["admin"],
             },
           },
@@ -684,9 +748,9 @@ describe("evaluate flag targeting integration ", () => {
         {
           code: "UNSUPPORTED_ARRAY_OPERATOR",
           field: "user.roles",
-          operator: "IS",
+          operator: "GT",
           message:
-            'Operator IS does not support array-valued context field "user.roles".',
+            'Operator GT does not support array-valued context field "user.roles".',
         },
       ]);
     });
@@ -702,7 +766,7 @@ describe("evaluate flag targeting integration ", () => {
               filter: {
                 type: "context",
                 field: "user.roles",
-                operator: "IS",
+                operator: "GT",
                 values: ["admin"],
               },
             },
@@ -728,7 +792,7 @@ describe("evaluate flag targeting integration ", () => {
                 {
                   type: "context",
                   field: "user.teams",
-                  operator: "IS",
+                  operator: "GT",
                   values: ["platform"],
                 },
                 { type: "constant", value: true },
@@ -1124,6 +1188,25 @@ describe("operator evaluation", () => {
   );
 
   it.each([
+    [["a"], "IS", ["a"], true],
+    [["a"], "IS_NOT", ["a"], false],
+    [["a", "b"], "IS", ["a"], false],
+    [["a", "b"], "IS_NOT", ["a"], true],
+    [["a", "a"], "IS", ["a"], false],
+    [["a", "a"], "IS_NOT", ["a"], true],
+    [[], "IS", ["a"], false],
+    [[], "IS_NOT", ["a"], true],
+    [["A"], "IS", ["a"], false],
+    [["A"], "IS_NOT", ["a"], true],
+    [["admin"], "IS", ["adm"], false],
+    [[""], "IS", [""], true],
+    [[""], "IS_NOT", [""], false],
+    [["a"], "IS", ["b", "a"], false],
+    [["a"], "IS_NOT", ["b", "a"], true],
+    [["a"], "IS", [], false],
+    [["a"], "IS_NOT", [], false],
+    [[], "IS", [], false],
+    [[], "IS_NOT", [], false],
     [["a", "b"], "CONTAINS", ["a"], true],
     [["a", "b"], "CONTAINS", ["c"], false],
     [["a", "b"], "NOT_CONTAINS", ["c"], true],
@@ -1162,8 +1245,6 @@ describe("operator evaluation", () => {
   );
 
   it.each([
-    "IS",
-    "IS_NOT",
     "GT",
     "LT",
     "AFTER",

--- a/packages/node-sdk/test/client.test.ts
+++ b/packages/node-sdk/test/client.test.ts
@@ -1756,6 +1756,62 @@ describe("ReflagClient", () => {
       expect(logger.warn).toHaveBeenCalledTimes(1);
     });
 
+    it.each(["CONTAINS", "NOT_CONTAINS"] as const)(
+      "evaluates array %s for targeting and config without warnings",
+      async (operator) => {
+        const filter = {
+          type: "context" as const,
+          field: "user.roles",
+          operator,
+          values: ["admin"],
+        };
+        const definitions: FlagsAPIResponse = {
+          flagStateVersion: 2,
+          features: [
+            {
+              key: "array-membership",
+              description: "Array membership",
+              targeting: { version: 1, rules: [{ filter }] },
+              config: {
+                version: 1,
+                variants: [
+                  { key: "matched", payload: { access: true }, filter },
+                ],
+              },
+            },
+          ],
+        };
+        httpClient.get.mockResolvedValue({
+          ok: true,
+          status: 200,
+          body: { success: true, ...definitions },
+        });
+        await client.initialize();
+
+        for (const [roles, contains] of [
+          [["admin", "editor"], true],
+          [["superadmin"], false],
+          [["Admin"], false],
+          [[], false],
+          // Scalars retain their case-insensitive substring semantics.
+          ["SUPERADMIN", true],
+        ] as const) {
+          const flag = client.getFlag(
+            { user: { id: "user123", roles } },
+            "array-membership",
+          );
+          const expected = operator === "CONTAINS" ? contains : !contains;
+          expect(flag.isEnabled).toBe(expected);
+          expect(flag.config).toEqual(
+            expected
+              ? { key: "matched", payload: { access: true } }
+              : { key: undefined, payload: undefined },
+          );
+        }
+        expect(logger.warn).not.toHaveBeenCalled();
+      },
+    );
+
     it("`isEnabled` warns about unsupported array operators", async () => {
       const arrayDefinitions: FlagsAPIResponse = {
         flagStateVersion: 2,
@@ -1770,7 +1826,7 @@ describe("ReflagClient", () => {
                   filter: {
                     type: "context",
                     field: "user.roles",
-                    operator: "CONTAINS",
+                    operator: "IS",
                     values: ["admin"],
                   },
                 },
@@ -1799,9 +1855,9 @@ describe("ReflagClient", () => {
             {
               code: "UNSUPPORTED_ARRAY_OPERATOR",
               field: "user.roles",
-              operator: "CONTAINS",
+              operator: "IS",
               message:
-                'Operator CONTAINS does not support array-valued context field "user.roles".',
+                'Operator IS does not support array-valued context field "user.roles".',
             },
           ],
         },
@@ -1835,7 +1891,7 @@ describe("ReflagClient", () => {
                   filter: {
                     type: "context",
                     field: "user.roles",
-                    operator: "CONTAINS",
+                    operator: "IS",
                     values: ["admin"],
                   },
                 },
@@ -1864,9 +1920,9 @@ describe("ReflagClient", () => {
             {
               code: "UNSUPPORTED_ARRAY_OPERATOR",
               field: "user.roles",
-              operator: "CONTAINS",
+              operator: "IS",
               message:
-                'Operator CONTAINS does not support array-valued context field "user.roles".',
+                'Operator IS does not support array-valued context field "user.roles".',
             },
           ],
         },

--- a/packages/node-sdk/test/client.test.ts
+++ b/packages/node-sdk/test/client.test.ts
@@ -1756,7 +1756,7 @@ describe("ReflagClient", () => {
       expect(logger.warn).toHaveBeenCalledTimes(1);
     });
 
-    it.each(["CONTAINS", "NOT_CONTAINS"] as const)(
+    it.each(["CONTAINS", "NOT_CONTAINS", "IS", "IS_NOT"] as const)(
       "evaluates array %s for targeting and config without warnings",
       async (operator) => {
         const filter = {
@@ -1788,19 +1788,27 @@ describe("ReflagClient", () => {
         });
         await client.initialize();
 
-        for (const [roles, contains] of [
-          [["admin", "editor"], true],
-          [["superadmin"], false],
-          [["Admin"], false],
-          [[], false],
-          // Scalars retain their case-insensitive substring semantics.
-          ["SUPERADMIN", true],
+        for (const [roles, contains, equals] of [
+          [["admin"], true, true],
+          [["admin", "editor"], true, false],
+          [["admin", "admin"], true, false],
+          [["superadmin"], false, false],
+          [["Admin"], false, false],
+          [[], false, false],
+          // Scalars retain substring matching and exact equality respectively.
+          ["SUPERADMIN", true, false],
+          ["admin", true, true],
         ] as const) {
           const flag = client.getFlag(
             { user: { id: "user123", roles } },
             "array-membership",
           );
-          const expected = operator === "CONTAINS" ? contains : !contains;
+          const positiveMatch =
+            operator === "IS" || operator === "IS_NOT" ? equals : contains;
+          const expected =
+            operator === "CONTAINS" || operator === "IS"
+              ? positiveMatch
+              : !positiveMatch;
           expect(flag.isEnabled).toBe(expected);
           expect(flag.config).toEqual(
             expected
@@ -1826,7 +1834,7 @@ describe("ReflagClient", () => {
                   filter: {
                     type: "context",
                     field: "user.roles",
-                    operator: "IS",
+                    operator: "GT",
                     values: ["admin"],
                   },
                 },
@@ -1855,9 +1863,9 @@ describe("ReflagClient", () => {
             {
               code: "UNSUPPORTED_ARRAY_OPERATOR",
               field: "user.roles",
-              operator: "IS",
+              operator: "GT",
               message:
-                'Operator IS does not support array-valued context field "user.roles".',
+                'Operator GT does not support array-valued context field "user.roles".',
             },
           ],
         },
@@ -1891,7 +1899,7 @@ describe("ReflagClient", () => {
                   filter: {
                     type: "context",
                     field: "user.roles",
-                    operator: "IS",
+                    operator: "GT",
                     values: ["admin"],
                   },
                 },
@@ -1920,9 +1928,9 @@ describe("ReflagClient", () => {
             {
               code: "UNSUPPORTED_ARRAY_OPERATOR",
               field: "user.roles",
-              operator: "IS",
+              operator: "GT",
               message:
-                'Operator IS does not support array-valued context field "user.roles".',
+                'Operator GT does not support array-valued context field "user.roles".',
             },
           ],
         },


### PR DESCRIPTION
## Summary
- `CONTAINS` matches if an array includes the specified value; `NOT_CONTAINS` checks its absence.
- `IS` matches arrays with exactly one matching element; `IS_NOT` matches all other present arrays, including empty arrays and duplicate matches.
- Array comparisons use normalized, case-sensitive whole values. Scalar equality and substring behavior are unchanged; missing context fields still fail closed.
- Patch changesets for evaluator 1.1.1 and Node SDK 1.7.3, including the updated evaluator dependency (plus dependent OpenFeature Node provider).

## Validation
- Evaluator: 243 tests passed
- Node SDK: 224 tests passed
- OpenFeature Node provider: 28 tests passed
- Targeted builds, lint, formatting pass
- Full monorepo build attempted; unrelated management SDK generation requires unavailable Java.

## Rollout
Not published yet. Web SQL/event-filter parity, backend/ingest dependency updates, and docs are separate follow-ups. Excludes transport PR #712 and Node SDK README changes.