### PR TITLE
Prevent toolbar renders from leaking after React SDK tests

### DIFF
--- a/packages/react-sdk/test/usage.test.tsx
+++ b/packages/react-sdk/test/usage.test.tsx
@@ -173,6 +173,10 @@ afterAll(() => server.close());
 beforeAll(() => {
   vi.spyOn(ReflagClient.prototype, "initialize");
   vi.spyOn(ReflagClient.prototype, "stop");
+  // Prevent Preact toolbar renders from outliving the jsdom test environment.
+  vi.spyOn(ReflagClient.prototype, "showToolbarToggle").mockImplementation(
+    () => undefined,
+  );
 });
 
 beforeEach(() => {


### PR DESCRIPTION
## Summary
- stub `showToolbarToggle` across the React SDK test suite
- prevent deferred Preact toolbar work from accessing jsdom globals after teardown
- cover providers and directly-created/external clients that do not use the shared `toolbar={false}` test helper

## Validation
- `yarn workspace @reflag/react-sdk test:types`
- `yarn workspace @reflag/react-sdk exec vitest run --reporter=dot` (65 tests passed)
- React SDK suite passed five consecutive runs before rebasing onto current `main`